### PR TITLE
Add a new collector for valug.at

### DIFF
--- a/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/BoudiccaEventCollectors.kt
+++ b/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/BoudiccaEventCollectors.kt
@@ -34,5 +34,6 @@ fun main() {
         .addEventCollector(StadthalleWienCollector())
         .addEventCollector(MuseumArbeitsweltCollector())
         .addEventCollector(OKHVoecklabruckCollector())
+        .addEventCollector(ValugCollector())
         .run()
 }

--- a/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/LocalCollectorDebug.kt
+++ b/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/LocalCollectorDebug.kt
@@ -20,7 +20,7 @@ fun main() {
 //        .debug(LandestheaterLinzCollector())
 //        .debug(KapuCollector())
 //        .debug(StadtwerkstattCollector())
-        .debug(OteloLinzCollector())
+//        .debug(OteloLinzCollector())
 //        .debug(EnnsEventsCollector())
 //        .debug(UlfOoeCollector())
 //        .debug(StiftskonzerteCollector())
@@ -33,4 +33,5 @@ fun main() {
 //        .debug(StadthalleWienCollector())
 //        .debug(MuseumArbeitsweltCollector())
 //        .debug(OKHVoecklabruckCollector())
+        .debug(ValugCollector())
 }

--- a/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/collectors/ValugCollector.kt
+++ b/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/collectors/ValugCollector.kt
@@ -51,12 +51,6 @@ class ValugCollector : TwoStepEventCollector<VEvent>("valug") {
                 put(SemanticKeys.ENDDATE, eventEndDate.format(DateTimeFormatter.ISO_DATE_TIME))
                 if (event.location != null) {
                     put(SemanticKeys.LOCATION_NAME, event.location.value)
-                    if (event.location.value.contains("VALUG-Klubraum")) {
-                        put(SemanticKeys.LOCATION_CITY, "Wels")
-                        put(SemanticKeys.LOCATION_URL, "https://valug.at/pages/Klubraum/")
-                        put(SemanticKeys.LOCATION_ADDRESS, "Dragonerstraße 22, 4600 Wels")
-                        put(SemanticKeys.LOCATION_COORDINATES, "14.01715, 48.15849")
-                    }
                 }
                 if (event.description != null) {
                     put(SemanticKeys.DESCRIPTION, event.description.value)

--- a/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/collectors/ValugCollector.kt
+++ b/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/collectors/ValugCollector.kt
@@ -1,0 +1,75 @@
+package events.boudicca.eventcollector.collectors
+
+import base.boudicca.SemanticKeys
+import base.boudicca.api.eventcollector.Fetcher
+import base.boudicca.api.eventcollector.TwoStepEventCollector
+import base.boudicca.model.Event
+import base.boudicca.model.EventCategory
+import net.fortuna.ical4j.data.CalendarBuilder
+import net.fortuna.ical4j.model.Calendar
+import net.fortuna.ical4j.model.component.VEvent
+import java.io.StringReader
+import java.net.URI
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.*
+
+/**
+ * VorAlpen Linux User Group
+ */
+class ValugCollector : TwoStepEventCollector<VEvent>("valug") {
+    private val fetcher = Fetcher()
+    private val baseUrl = "https://valug.at/"
+    private val icsUrl = "${baseUrl}events/index.ics"
+
+    override fun getAllUnparsedEvents(): List<VEvent> {
+        val feed = fetcher.fetchUrl(icsUrl)
+        val builder = CalendarBuilder()
+        val calendar: Calendar = builder.build(StringReader(feed))
+        return calendar.components.filterIsInstance<VEvent>()
+    }
+
+    override fun parseEvent(event: VEvent): Event? {
+        val eventName = event.summary.value
+        val formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss")
+        // get by city name to account for daylight saving time
+        val viennaZoneId = TimeZone.getTimeZone("Europe/Vienna").toZoneId()
+        val eventStartDate = LocalDateTime.parse(event.startDate.value, formatter)
+            .atZone(viennaZoneId).toOffsetDateTime()
+        val now = LocalDateTime.now().atZone(viennaZoneId).toOffsetDateTime()
+
+        if (eventStartDate.isBefore(now)) {
+            return null
+        }
+
+        val eventEndDate = LocalDateTime.parse(event.startDate.value, formatter)
+            .atZone(TimeZone.getTimeZone("Europe/Vienna").toZoneId()).toOffsetDateTime()
+
+        return Event(
+            eventName, eventStartDate,
+            buildMap {
+                put(SemanticKeys.ENDDATE, eventEndDate.format(DateTimeFormatter.ISO_DATE_TIME))
+                if (event.location != null) {
+                    put(SemanticKeys.LOCATION_NAME, event.location.value)
+                    if (event.location.value.contains("VALUG-Klubraum")) {
+                        put(SemanticKeys.LOCATION_CITY, "Wels")
+                        put(SemanticKeys.LOCATION_URL, "https://valug.at/pages/Klubraum/")
+                        put(SemanticKeys.LOCATION_ADDRESS, "Dragonerstraße 22, 4600 Wels")
+                        put(SemanticKeys.LOCATION_COORDINATES, "14.01715, 48.15849")
+                    }
+                }
+                if (event.description != null) {
+                    put(SemanticKeys.DESCRIPTION, event.description.value)
+                }
+                put(SemanticKeys.TAGS, listOf("VALUG", "Linux", "User Group").toString())
+                put(SemanticKeys.URL, event.url.value)
+                put(SemanticKeys.TYPE, "techmeetup") // TODO same as with Technologieplauscherl
+                put(SemanticKeys.CATEGORY, EventCategory.TECH.name)
+                put(SemanticKeys.REGISTRATION, "free")
+                put("url.ics", icsUrl)
+                put("valug.uid", event.uid.value)
+                put(SemanticKeys.SOURCES, "${icsUrl}\n${baseUrl}")
+            }
+        )
+    }
+}

--- a/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/collectors/ValugCollector.kt
+++ b/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/collectors/ValugCollector.kt
@@ -29,19 +29,13 @@ class ValugCollector : TwoStepEventCollector<VEvent>("valug") {
         return calendar.components.filterIsInstance<VEvent>()
     }
 
-    override fun parseEvent(event: VEvent): Event? {
+    override fun parseEvent(event: VEvent): Event {
         val eventName = event.summary.value
         val formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss")
         // get by city name to account for daylight saving time
         val viennaZoneId = TimeZone.getTimeZone("Europe/Vienna").toZoneId()
         val eventStartDate = LocalDateTime.parse(event.startDate.value, formatter)
             .atZone(viennaZoneId).toOffsetDateTime()
-        val now = LocalDateTime.now().atZone(viennaZoneId).toOffsetDateTime()
-
-        if (eventStartDate.isBefore(now)) {
-            return null
-        }
-
         val eventEndDate = LocalDateTime.parse(event.startDate.value, formatter)
             .atZone(TimeZone.getTimeZone("Europe/Vienna").toZoneId()).toOffsetDateTime()
 


### PR DESCRIPTION
VorAlpen Linux User Group is a local Linux user community that meets regularly. Most events happen at the Klubraum. If the ical event location contains this keyword, further geolocation is added.

The Klubraum is also marked on OpenStreetMap with the current ID of [99255999](https://www.openstreetmap.org/way/99255999). If I understand correctly, [there does not exist any permanent ID](https://wiki.openstreetmap.org/wiki/Permanent_ID) for POIs, except for the wikidata page. The Klubraum or VALUG has no wikidata page. Do you already have a standard how to handle this?

The Klubraum is located on the second floor and only accessible by stairs. Does the absence of `accessibility.accessibleEntry` imply a value of `false` or should this be explicitly set?