### PR TITLE
Abl/recurrence

### DIFF
--- a/QUERY.md
+++ b/QUERY.md
@@ -22,6 +22,7 @@ potentially nested) forms. Please note that expressions are case-insensitive:
 | Before          | Filter events starting at or before the given date                                                                                                       | `<dateFieldname> before <date>`                                                     |
 | Grouping        | Marker to identify how expression should be grouped                                                                                                      | `( <expression> )`                                                                  |
 | Duration        | Filter events on their duration in hours (inclusive), events without startDate or endDate have 0 duration. You an filter for longer or shorter duration. | `duration <fieldname of startDate> <fieldname of endDate> longer\|shorter <number>` |
+| HasField        | Checks that the event has this field set, and it is not the empty string.                                                                                | `hasField <fieldname>`                                                              |
 
 where
 

--- a/SEMANTIC_CONVENTIONS.md
+++ b/SEMANTIC_CONVENTIONS.md
@@ -28,20 +28,21 @@ We use certain data types for the properties we expect.
 
 **Events have only two required properties: `name` and `startDate`**
 
-| Key           | Meaning                                                                                              | Format                               |
-|---------------|------------------------------------------------------------------------------------------------------|--------------------------------------|
-| name          | The name of the event                                                                                | text                                 |
-| startDate     | Time of start for the event                                                                          | date                                 |
-| endDate       | Time of end for the event                                                                            | date                                 |
-| url           | A link to the website for this event                                                                 | url                                  |
-| type          | The type of event, for example `concert`, `????` more examples please                                | text ??? maybe enum would be better? |
-| category      | The category of an event, for example `MUSIC`, `ART` or `TECH`, see EventCategory enum               | enum\<EventCategory>                 |
-| description   | Text describing this event                                                                           | text                                 |
-| tags          | A list of tags. TODO how to describe?                                                                | list\<text>                          |
-| registration  | If this is a free event, a event which requires registration or a event which requires a paid ticket | enum\<registration>                  |
-| pictureUrl    | Url to a picture to be shown                                                                         | url                                  |
-| collectorName | Name of the collector which collected this event                                                     | text                                 |
-| sources       | A list of all sources, line by line. This should include all URLs or other sources used.             | list\<text>                          |
+| Key           | Meaning                                                                                                                                                    | Format                               |
+|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| name          | The name of the event                                                                                                                                      | text                                 |
+| startDate     | Time of start for the event                                                                                                                                | date                                 |
+| endDate       | Time of end for the event                                                                                                                                  | date                                 |
+| url           | A link to the website for this event                                                                                                                       | url                                  |
+| type          | The type of event, for example `concert`, `????` more examples please                                                                                      | text ??? maybe enum would be better? |
+| category      | The category of an event, for example `MUSIC`, `ART` or `TECH`, see EventCategory enum                                                                     | enum\<EventCategory>                 |
+| description   | Text describing this event                                                                                                                                 | text                                 |
+| tags          | A list of tags. TODO how to describe?                                                                                                                      | list\<text>                          |
+| registration  | If this is a free event, a event which requires registration or a event which requires a paid ticket                                                       | enum\<Registration>                  |
+| pictureUrl    | Url to a picture to be shown                                                                                                                               | url                                  |
+| collectorName | Name of the collector which collected this event                                                                                                           | text                                 |
+| sources       | A list of all sources, line by line. This should include all URLs or other sources used.                                                                   | list\<text>                          |
+| recurrence    | If an event happens multiple times you can set this value to a human-readable description of the recurrence. If not set it means this is a one-time event. | text                                 |
 
 #### Registration enum values
 

--- a/SEMANTIC_CONVENTIONS.md
+++ b/SEMANTIC_CONVENTIONS.md
@@ -28,21 +28,22 @@ We use certain data types for the properties we expect.
 
 **Events have only two required properties: `name` and `startDate`**
 
-| Key           | Meaning                                                                                                                                                    | Format                               |
-|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| name          | The name of the event                                                                                                                                      | text                                 |
-| startDate     | Time of start for the event                                                                                                                                | date                                 |
-| endDate       | Time of end for the event                                                                                                                                  | date                                 |
-| url           | A link to the website for this event                                                                                                                       | url                                  |
-| type          | The type of event, for example `concert`, `????` more examples please                                                                                      | text ??? maybe enum would be better? |
-| category      | The category of an event, for example `MUSIC`, `ART` or `TECH`, see EventCategory enum                                                                     | enum\<EventCategory>                 |
-| description   | Text describing this event                                                                                                                                 | text                                 |
-| tags          | A list of tags. TODO how to describe?                                                                                                                      | list\<text>                          |
-| registration  | If this is a free event, a event which requires registration or a event which requires a paid ticket                                                       | enum\<Registration>                  |
-| pictureUrl    | Url to a picture to be shown                                                                                                                               | url                                  |
-| collectorName | Name of the collector which collected this event                                                                                                           | text                                 |
-| sources       | A list of all sources, line by line. This should include all URLs or other sources used.                                                                   | list\<text>                          |
-| recurrence    | If an event happens multiple times you can set this value to a human-readable description of the recurrence. If not set it means this is a one-time event. | text                                 |
+| Key                 | Meaning                                                                                              | Format                               |
+|---------------------|------------------------------------------------------------------------------------------------------|--------------------------------------|
+| name                | The name of the event                                                                                | text                                 |
+| startDate           | Time of start for the event                                                                          | date                                 |
+| endDate             | Time of end for the event                                                                            | date                                 |
+| url                 | A link to the website for this event                                                                 | url                                  |
+| type                | The type of event, for example `concert`, `????` more examples please                                | text ??? maybe enum would be better? |
+| category            | The category of an event, for example `MUSIC`, `ART` or `TECH`, see EventCategory enum               | enum\<EventCategory>                 |
+| description         | Text describing this event                                                                           | text                                 |
+| tags                | A list of tags. TODO how to describe?                                                                | list\<text>                          |
+| registration        | If this is a free event, a event which requires registration or a event which requires a paid ticket | enum\<Registration>                  |
+| pictureUrl          | Url to a picture to be shown                                                                         | url                                  |
+| collectorName       | Name of the collector which collected this event                                                     | text                                 |
+| sources             | A list of all sources, line by line. This should include all URLs or other sources used.             | list\<text>                          |
+| recurrence.type     | Describing how often an event happens. Once, rarely or very often.                                   | enum\<RecurrenceType>                |
+| recurrence.interval | Describing the interval with which the event recurs                                                  | text                                 |
 
 #### Registration enum values
 
@@ -82,6 +83,24 @@ We use certain data types for the properties we expect.
 |------------------|---------------------------|------------|
 | concert.genre    | Genre of the concert      | text       |
 | concert.bandlist | List of all bands playing | list<text> |
+
+#### RecurrenceType enum values
+
+* `REGULARLY`: events that happen about once a week or more often over the period of multiple months
+* `RARELY`: events that occur about once a month throughout the year
+* `ONCE`: events that occur once a year or more rarely (e.g. Christmas/Easter specials). When the same event is repeated
+  e.g. 3 times (for example so that more people can register), but only once a year, it should still be tagged as ONCE.
+
+Examples:
+
+* There is a special event with oldtimers on a museum railway that takes 2 days, but only happens once per year.
+  * should be tagged as ONCE
+* There is a special event with oldtimers on a museum railway that takes 2 days, but only happens once per year.
+  * should be tagged as ONCE
+* during Summer from June to September every Thursday there is a special train
+  * should be tagged as REGULARLY
+* a specific meetup happens about once per month or every two months
+  * should be tagged as RARELY
 
 ### Internal Properties
 

--- a/boudicca.base/enricher/src/main/kotlin/base/boudicca/enricher/service/Enricher.kt
+++ b/boudicca.base/enricher/src/main/kotlin/base/boudicca/enricher/service/Enricher.kt
@@ -4,5 +4,11 @@ import base.boudicca.model.Event
 
 
 interface Enricher {
-    fun enrich(e: Event): Event
+    fun enrich(e: Event): Event {
+        throw NotImplementedError("enricher has not implement list or single enrich operation")
+    }
+
+    fun enrich(events: List<Event>): List<Event> {
+        return events.map { enrich(it) }
+    }
 }

--- a/boudicca.base/enricher/src/main/kotlin/base/boudicca/enricher/service/EnricherService.kt
+++ b/boudicca.base/enricher/src/main/kotlin/base/boudicca/enricher/service/EnricherService.kt
@@ -13,13 +13,11 @@ class EnricherService @Autowired constructor(
 ) {
 
     fun enrich(enrichRequestDTO: EnrichRequestDTO): List<Event> {
-        return (enrichRequestDTO.events ?: emptyList()).map {
-            var enrichedEvent = it
-            for (enricher in enrichers) {
-                enrichedEvent = enricher.enrich(enrichedEvent)
-            }
-            enrichedEvent
+        var enrichedEvents = enrichRequestDTO.events ?: emptyList()
+        for (enricher in enrichers) {
+            enrichedEvents = enricher.enrich(enrichedEvents)
         }
+        return enrichedEvents
     }
 
     fun forceUpdate() {

--- a/boudicca.base/enricher/src/main/kotlin/base/boudicca/enricher/service/RecurrenceEnricher.kt
+++ b/boudicca.base/enricher/src/main/kotlin/base/boudicca/enricher/service/RecurrenceEnricher.kt
@@ -1,0 +1,37 @@
+package base.boudicca.enricher.service
+
+import base.boudicca.SemanticKeys
+import base.boudicca.model.Event
+import org.springframework.stereotype.Service
+
+@Service
+class RecurrenceEnricher : Enricher {
+
+    override fun enrich(events: List<Event>): List<Event> {
+        val nameGroups = events.groupBy { it.name }
+
+        return events.map {
+            if (groupIsRecurring(nameGroups[it.name]!!)) {
+                addRecurrence(it)
+            } else {
+                it
+            }
+        }
+    }
+
+    private fun groupIsRecurring(group: List<Event>): Boolean {
+        //TODO arbitrary number 3, add better detection
+        return group.size > 3
+    }
+
+    private fun addRecurrence(event: Event): Event {
+        //honor existing recurrence value
+        if (event.data.containsKey(SemanticKeys.RECURRENCE)) {
+            return event
+        }
+        val data = event.data.toMutableMap()
+        data[SemanticKeys.RECURRENCE] = "recurring"
+        return Event(event.name, event.startDate, data)
+    }
+
+}

--- a/boudicca.base/enricher/src/main/kotlin/base/boudicca/enricher/service/RecurrenceEnricher.kt
+++ b/boudicca.base/enricher/src/main/kotlin/base/boudicca/enricher/service/RecurrenceEnricher.kt
@@ -26,11 +26,11 @@ class RecurrenceEnricher : Enricher {
 
     private fun addRecurrence(event: Event): Event {
         //honor existing recurrence value
-        if (event.data.containsKey(SemanticKeys.RECURRENCE)) {
+        if (event.data.containsKey(SemanticKeys.RECURRENCE_TYPE)) {
             return event
         }
         val data = event.data.toMutableMap()
-        data[SemanticKeys.RECURRENCE] = "recurring"
+        data[SemanticKeys.RECURRENCE_TYPE] = "REGULARLY"
         return Event(event.name, event.startDate, data)
     }
 

--- a/boudicca.base/enricher/src/test/kotlin/base/boudicca/enricher/service/RecurrenceEnricherTest.kt
+++ b/boudicca.base/enricher/src/test/kotlin/base/boudicca/enricher/service/RecurrenceEnricherTest.kt
@@ -16,17 +16,17 @@ class RecurrenceEnricherTest {
                 Event("group 1", OffsetDateTime.now().plusDays(1), mapOf()),
                 Event("group 1", OffsetDateTime.now().plusDays(2), mapOf()),
                 Event("group 1", OffsetDateTime.now().plusDays(3), mapOf()),
-                Event("group 1", OffsetDateTime.now().plusDays(4), mapOf(SemanticKeys.RECURRENCE to "something")),
+                Event("group 1", OffsetDateTime.now().plusDays(4), mapOf(SemanticKeys.RECURRENCE_TYPE to "something")),
                 //group 2 should NOT be detected as recurring
                 Event("group 2", OffsetDateTime.now().plusDays(5), mapOf()),
-                Event("group 2", OffsetDateTime.now().plusDays(6), mapOf(SemanticKeys.RECURRENCE to "something")),
+                Event("group 2", OffsetDateTime.now().plusDays(6), mapOf(SemanticKeys.RECURRENCE_TYPE to "something")),
             )
         )
-        assertEquals("recurring", enriched[0].data[SemanticKeys.RECURRENCE])
-        assertEquals("recurring", enriched[1].data[SemanticKeys.RECURRENCE])
-        assertEquals("recurring", enriched[2].data[SemanticKeys.RECURRENCE])
-        assertEquals("something", enriched[3].data[SemanticKeys.RECURRENCE])
-        assertEquals(null, enriched[4].data[SemanticKeys.RECURRENCE])
-        assertEquals("something", enriched[5].data[SemanticKeys.RECURRENCE])
+        assertEquals("REGULARLY", enriched[0].data[SemanticKeys.RECURRENCE_TYPE])
+        assertEquals("REGULARLY", enriched[1].data[SemanticKeys.RECURRENCE_TYPE])
+        assertEquals("REGULARLY", enriched[2].data[SemanticKeys.RECURRENCE_TYPE])
+        assertEquals("something", enriched[3].data[SemanticKeys.RECURRENCE_TYPE])
+        assertEquals(null, enriched[4].data[SemanticKeys.RECURRENCE_TYPE])
+        assertEquals("something", enriched[5].data[SemanticKeys.RECURRENCE_TYPE])
     }
 }

--- a/boudicca.base/enricher/src/test/kotlin/base/boudicca/enricher/service/RecurrenceEnricherTest.kt
+++ b/boudicca.base/enricher/src/test/kotlin/base/boudicca/enricher/service/RecurrenceEnricherTest.kt
@@ -1,0 +1,32 @@
+package base.boudicca.enricher.service
+
+import base.boudicca.SemanticKeys
+import base.boudicca.model.Event
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+
+class RecurrenceEnricherTest {
+
+    @Test
+    fun testSimple() {
+        val enriched = RecurrenceEnricher().enrich(
+            listOf(
+                //group 1 should be detected as recurring
+                Event("group 1", OffsetDateTime.now().plusDays(1), mapOf()),
+                Event("group 1", OffsetDateTime.now().plusDays(2), mapOf()),
+                Event("group 1", OffsetDateTime.now().plusDays(3), mapOf()),
+                Event("group 1", OffsetDateTime.now().plusDays(4), mapOf(SemanticKeys.RECURRENCE to "something")),
+                //group 2 should NOT be detected as recurring
+                Event("group 2", OffsetDateTime.now().plusDays(5), mapOf()),
+                Event("group 2", OffsetDateTime.now().plusDays(6), mapOf(SemanticKeys.RECURRENCE to "something")),
+            )
+        )
+        assertEquals("recurring", enriched[0].data[SemanticKeys.RECURRENCE])
+        assertEquals("recurring", enriched[1].data[SemanticKeys.RECURRENCE])
+        assertEquals("recurring", enriched[2].data[SemanticKeys.RECURRENCE])
+        assertEquals("something", enriched[3].data[SemanticKeys.RECURRENCE])
+        assertEquals(null, enriched[4].data[SemanticKeys.RECURRENCE])
+        assertEquals("something", enriched[5].data[SemanticKeys.RECURRENCE])
+    }
+}

--- a/boudicca.base/publisher-event-html/src/main/kotlin/base/boudicca/publisher/event/html/model/SearchDTO.kt
+++ b/boudicca.base/publisher-event-html/src/main/kotlin/base/boudicca/publisher/event/html/model/SearchDTO.kt
@@ -14,7 +14,7 @@ data class SearchDTO(
     @RequestParam("durationShorter", required = false) var durationShorter: Double?,
     @RequestParam("durationLonger", required = false) var durationLonger: Double?,
     @RequestParam("bandName", required = false) var bandName: String?,
-    @RequestParam("recurrence", required = false) var recurrence: Boolean?,
+    @RequestParam("includeRecurring", required = false) var includeRecurring: Boolean?,
 ) {
     constructor() : this(null, null, null, null, null, null, null, null, null, null, null, null)
 }

--- a/boudicca.base/publisher-event-html/src/main/kotlin/base/boudicca/publisher/event/html/model/SearchDTO.kt
+++ b/boudicca.base/publisher-event-html/src/main/kotlin/base/boudicca/publisher/event/html/model/SearchDTO.kt
@@ -14,6 +14,7 @@ data class SearchDTO(
     @RequestParam("durationShorter", required = false) var durationShorter: Double?,
     @RequestParam("durationLonger", required = false) var durationLonger: Double?,
     @RequestParam("bandName", required = false) var bandName: String?,
+    @RequestParam("recurrence", required = false) var recurrence: Boolean?,
 ) {
-    constructor() : this(null, null, null, null, null, null, null, null, null, null, null)
+    constructor() : this(null, null, null, null, null, null, null, null, null, null, null, null)
 }

--- a/boudicca.base/publisher-event-html/src/main/kotlin/base/boudicca/publisher/event/html/service/EventService.kt
+++ b/boudicca.base/publisher-event-html/src/main/kotlin/base/boudicca/publisher/event/html/service/EventService.kt
@@ -9,6 +9,8 @@ import base.boudicca.api.search.BoudiccaQueryBuilder.contains
 import base.boudicca.api.search.BoudiccaQueryBuilder.durationLonger
 import base.boudicca.api.search.BoudiccaQueryBuilder.durationShorter
 import base.boudicca.api.search.BoudiccaQueryBuilder.equals
+import base.boudicca.api.search.BoudiccaQueryBuilder.hasField
+import base.boudicca.api.search.BoudiccaQueryBuilder.not
 import base.boudicca.model.Event
 import base.boudicca.model.EventCategory
 import base.boudicca.publisher.event.html.model.SearchDTO
@@ -82,6 +84,9 @@ class EventService @Autowired constructor(@Value("\${boudicca.search.url}") priv
         }
         if (!searchDTO.bandName.isNullOrBlank()) {
             queryParts.add(contains(SemanticKeys.CONCERT_BANDLIST, searchDTO.bandName!!))
+        }
+        if (searchDTO.recurrence != true) {
+            queryParts.add(not(hasField(SemanticKeys.RECURRENCE)))
         }
         return and(queryParts)
     }

--- a/boudicca.base/publisher-event-html/src/main/kotlin/base/boudicca/publisher/event/html/service/EventService.kt
+++ b/boudicca.base/publisher-event-html/src/main/kotlin/base/boudicca/publisher/event/html/service/EventService.kt
@@ -11,6 +11,7 @@ import base.boudicca.api.search.BoudiccaQueryBuilder.durationShorter
 import base.boudicca.api.search.BoudiccaQueryBuilder.equals
 import base.boudicca.api.search.BoudiccaQueryBuilder.hasField
 import base.boudicca.api.search.BoudiccaQueryBuilder.not
+import base.boudicca.api.search.BoudiccaQueryBuilder.or
 import base.boudicca.model.Event
 import base.boudicca.model.EventCategory
 import base.boudicca.publisher.event.html.model.SearchDTO
@@ -85,8 +86,13 @@ class EventService @Autowired constructor(@Value("\${boudicca.search.url}") priv
         if (!searchDTO.bandName.isNullOrBlank()) {
             queryParts.add(contains(SemanticKeys.CONCERT_BANDLIST, searchDTO.bandName!!))
         }
-        if (searchDTO.recurrence != true) {
-            queryParts.add(not(hasField(SemanticKeys.RECURRENCE)))
+        if (searchDTO.includeRecurring != true) {
+            queryParts.add(
+                or(
+                    not(hasField(SemanticKeys.RECURRENCE_TYPE)),
+                    equals(SemanticKeys.RECURRENCE_TYPE, "ONCE")
+                )
+            )
         }
         return and(queryParts)
     }

--- a/boudicca.base/publisher-event-html/src/main/resources/templates/layout/drawer.hbs
+++ b/boudicca.base/publisher-event-html/src/main/resources/templates/layout/drawer.hbs
@@ -99,6 +99,10 @@
                         {{/each}}
                     </select>
                 </div>
+                <div class="filter-input-wrapper">
+                    <label for="recurrence" class="filter-label">Zeige sich wiederholende Veranstaltungen</label>
+                    <input type="checkbox" id="recurrence" name="recurrence">
+                </div>
             </div>
         </div>
     </fieldset>

--- a/boudicca.base/publisher-event-html/src/main/resources/templates/layout/drawer.hbs
+++ b/boudicca.base/publisher-event-html/src/main/resources/templates/layout/drawer.hbs
@@ -100,8 +100,8 @@
                     </select>
                 </div>
                 <div class="filter-input-wrapper">
-                    <label for="recurrence" class="filter-label">Zeige sich wiederholende Veranstaltungen</label>
-                    <input type="checkbox" id="recurrence" name="recurrence">
+                    <label for="includeRecurring" class="filter-label">Zeige sich wiederholende Veranstaltungen</label>
+                    <input type="checkbox" id="includeRecurring" name="includeRecurring">
                 </div>
             </div>
         </div>

--- a/boudicca.base/search-client/src/main/kotlin/base/boudicca/api/search/BoudiccaQueryBuilder.kt
+++ b/boudicca.base/search-client/src/main/kotlin/base/boudicca/api/search/BoudiccaQueryBuilder.kt
@@ -58,6 +58,10 @@ object BoudiccaQueryBuilder {
         return "duration ${escapeText(startDateField)} ${escapeText(endDateField)} shorter $hours"
     }
 
+    fun hasField(field: String): String {
+        return "hasField ${escapeText(field)}"
+    }
+
     fun escapeText(text: String): String {
         return "\"" + text.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
     }

--- a/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/Expression.kt
+++ b/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/Expression.kt
@@ -60,6 +60,20 @@ abstract class FieldAndTextExpression(
     }
 }
 
+abstract class FieldExpression(
+    private val name: String,
+    private val fieldName: String,
+) : Expression {
+
+    fun getFieldName(): String {
+        return fieldName
+    }
+
+    override fun toString(): String {
+        return "$name('$fieldName')"
+    }
+}
+
 abstract class DateExpression(
     private val name: String,
     dateFieldName: String,
@@ -154,3 +168,7 @@ class DurationLongerExpression(
     endDateField: String,
     duration: Number,
 ) : AbstractDurationExpression("DURATIONLONGER", startDateField, endDateField, duration)
+
+class HasFieldExpression(
+    fieldName: String,
+) : FieldExpression("HASFIELD", fieldName)

--- a/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/Lexer.kt
+++ b/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/Lexer.kt
@@ -82,6 +82,7 @@ class Lexer(private val query: String) {
             "duration" -> tokens.add(Token(TokenType.DURATION, null))
             "longer" -> tokens.add(Token(TokenType.LONGER, null))
             "shorter" -> tokens.add(Token(TokenType.SHORTER, null))
+            "hasfield" -> tokens.add(Token(TokenType.HAS_FIELD, null))
             else -> throw QueryException("unknown keyword: $token (did you forget to quote your text?)")
         }
         i = tokenEnd

--- a/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/Parser.kt
+++ b/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/Parser.kt
@@ -58,6 +58,10 @@ class Parser(private val tokens: List<Token>) {
                 return parseDuration()
             }
 
+            TokenType.HAS_FIELD -> {
+                return parseHasField()
+            }
+
             else -> throw QueryException("invalid token ${getCurrentTokenType()}")
         }
     }
@@ -106,6 +110,12 @@ class Parser(private val tokens: List<Token>) {
 
             else -> throw QueryException("invalid token ${getCurrentTokenType()} following after text token")
         }
+    }
+
+    private fun parseHasField(): HasFieldExpression {
+        i++
+        val field = checkText()
+        return HasFieldExpression(field)
     }
 
     private fun parseGrouping(): Expression {

--- a/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/Token.kt
+++ b/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/Token.kt
@@ -34,4 +34,5 @@ enum class TokenType {
     DURATION,
     LONGER,
     SHORTER,
+    HAS_FIELD,
 }

--- a/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/evaluator/SimpleEvaluator.kt
+++ b/boudicca.base/search/src/main/kotlin/base/boudicca/search/service/query/evaluator/SimpleEvaluator.kt
@@ -95,6 +95,10 @@ class SimpleEvaluator(rawEntries: Collection<Entry>) : Evaluator {
                 return duration <= expression.getDuration().toDouble()
             }
 
+            is HasFieldExpression -> {
+                return event.containsKey(expression.getFieldName()) && event[expression.getFieldName()]!!.isNotEmpty()
+            }
+
             else -> {
                 throw QueryException("unknown expression kind $expression")
             }

--- a/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/LexerTest.kt
+++ b/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/LexerTest.kt
@@ -244,6 +244,13 @@ class LexerTest {
         assertEquals(BigDecimal(-2.5), tokens[0].getNumber())
     }
 
+    @Test
+    fun testHasFieldKeyword() {
+        val tokens = callLexer(""" hasField """)
+        assertEquals(1, tokens.size)
+        assertEquals(TokenType.HAS_FIELD, tokens[0].getType())
+    }
+
     private fun callLexer(query: String): List<Token> {
         return Lexer(query).lex()
     }

--- a/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/ParserTest.kt
+++ b/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/ParserTest.kt
@@ -231,6 +231,16 @@ class ParserTest {
         )
     }
 
+    @Test
+    fun testHasField() {
+        assertEquals(
+            "HASFIELD('field')",
+            callParser(
+                hasField(), text("field")
+            )
+        )
+    }
+
     private fun before(): Token {
         return Token(TokenType.BEFORE, null)
     }
@@ -285,6 +295,10 @@ class ParserTest {
 
     private fun longer(): Token {
         return Token(TokenType.LONGER, null)
+    }
+
+    private fun hasField(): Token {
+        return Token(TokenType.HAS_FIELD, null)
     }
 
     private fun callParser(vararg tokens: Token): String {

--- a/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/QueryTest.kt
+++ b/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/QueryTest.kt
@@ -72,6 +72,14 @@ class QueryTest {
         assertFalse(events.map { it["name"] }.contains("event1"))
     }
 
+    @Test
+    fun queryWithHasField() {
+        val events =
+            evaluateQuery(""" hasField "recurrence" """)
+        assertEquals(1, events.size)
+        assertEquals("event2", events.first()["name"])
+    }
+
     private fun evaluateQuery(string: String): Collection<Map<String, String>> {
         return SimpleEvaluator(testData())
             .evaluate(QueryParser.parseQuery(string), PAGE_ALL)
@@ -91,7 +99,8 @@ class QueryTest {
                 "name" to "event2",
                 "field" to "value2",
                 SemanticKeys.STARTDATE to "2023-05-29T00:00:00Z",
-                SemanticKeys.TYPE to "theater"
+                SemanticKeys.TYPE to "theater",
+                SemanticKeys.RECURRENCE to "yes"
             ),
             mapOf(
                 "name" to "somethingelse", "field" to "wuuut",

--- a/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/QueryTest.kt
+++ b/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/QueryTest.kt
@@ -75,7 +75,7 @@ class QueryTest {
     @Test
     fun queryWithHasField() {
         val events =
-            evaluateQuery(""" hasField "recurrence" """)
+            evaluateQuery(""" hasField "recurrence.type" """)
         assertEquals(1, events.size)
         assertEquals("event2", events.first()["name"])
     }
@@ -100,7 +100,7 @@ class QueryTest {
                 "field" to "value2",
                 SemanticKeys.STARTDATE to "2023-05-29T00:00:00Z",
                 SemanticKeys.TYPE to "theater",
-                SemanticKeys.RECURRENCE to "yes"
+                SemanticKeys.RECURRENCE_TYPE to "REGULARLY"
             ),
             mapOf(
                 "name" to "somethingelse", "field" to "wuuut",

--- a/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/evaluator/SimpleEvaluatorTest.kt
+++ b/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/evaluator/SimpleEvaluatorTest.kt
@@ -228,6 +228,25 @@ class SimpleEvaluatorTest {
         assertEquals("event1", events.first()["name"])
     }
 
+    @Test
+    fun hasField() {
+        val events =
+            callEvaluator(
+                HasFieldExpression("recurrence"),
+                listOf(
+                    mapOf(
+                        SemanticKeys.NAME to "event1",
+                    ),
+                    mapOf(
+                        SemanticKeys.NAME to "event2",
+                        SemanticKeys.RECURRENCE to "yes",
+                    ),
+                )
+            )
+        assertEquals(1, events.size)
+        assertEquals("event2", events.first()["name"])
+    }
+
 
     private fun callEvaluator(expression: Expression): Collection<Entry> {
         return callEvaluator(expression, testData())

--- a/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/evaluator/SimpleEvaluatorTest.kt
+++ b/boudicca.base/search/src/test/kotlin/base/boudicca/search/query/evaluator/SimpleEvaluatorTest.kt
@@ -232,14 +232,14 @@ class SimpleEvaluatorTest {
     fun hasField() {
         val events =
             callEvaluator(
-                HasFieldExpression("recurrence"),
+                HasFieldExpression("recurrence.type"),
                 listOf(
                     mapOf(
                         SemanticKeys.NAME to "event1",
                     ),
                     mapOf(
                         SemanticKeys.NAME to "event2",
-                        SemanticKeys.RECURRENCE to "yes",
+                        SemanticKeys.RECURRENCE_TYPE to "REGULARLY",
                     ),
                 )
             )

--- a/boudicca.base/semantic-conventions/src/main/kotlin/base/boudicca/SemanticKeys.kt
+++ b/boudicca.base/semantic-conventions/src/main/kotlin/base/boudicca/SemanticKeys.kt
@@ -14,7 +14,8 @@ object SemanticKeys {
     const val PICTUREURL = "pictureUrl"
     const val COLLECTORNAME = "collectorName"
     const val SOURCES = "sources"
-    const val RECURRENCE = "recurrence"
+    const val RECURRENCE_TYPE = "recurrence.type"
+    const val RECURRENCE_INTERVAL = "recurrence.interval"
 
     // location properties
     const val LOCATION_NAME = "location.name"

--- a/boudicca.base/semantic-conventions/src/main/kotlin/base/boudicca/SemanticKeys.kt
+++ b/boudicca.base/semantic-conventions/src/main/kotlin/base/boudicca/SemanticKeys.kt
@@ -14,6 +14,7 @@ object SemanticKeys {
     const val PICTUREURL = "pictureUrl"
     const val COLLECTORNAME = "collectorName"
     const val SOURCES = "sources"
+    const val RECURRENCE = "recurrence"
 
     // location properties
     const val LOCATION_NAME = "location.name"


### PR DESCRIPTION
solves #277

first cheap implementation for the recurrence detection

i changed the field and the meaning a bit, but i am not sure if i like it this way.
for now the field is "recurrence" and if it is set it means the event is recurring, and if it is not set it means it is not recurring. also i said there are no predefined values per se but just human-readable text.
but i am wondering if this is a good idea, 
maybe we should add some value you can set and which means not recurring/one time
and maybe we should go back to some pre-defined values, but which ones would we use?

also, the detection is a bit wonky right now :D
if there are 4 or more events with the same date we say something is recurring, otherwise not. works surprisingly well for the data i looked at :D 

but there are some events i am not sure if i like them to be classified as recurring: theater performances. pretty much all theater events are now marked as recurring events. because, well, basically they are. but intuitively it feels wrong to me? not sure why though...