### PR TITLE
Abl/refactor collector

### DIFF
--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectionRunner.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectionRunner.kt
@@ -17,8 +17,7 @@ class EventCollectionRunner(
 ) {
 
     private val LOG = LoggerFactory.getLogger(this::class.java)
-    private val executor =
-        Executors.newCachedThreadPool { Thread(it).apply { isDaemon = true } } //TODO change to virtualthreads
+    private val executor = Executors.newVirtualThreadPerTaskExecutor()
 
     /**
      * executes a full collection for all configured eventcollectors

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectionRunner.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectionRunner.kt
@@ -1,0 +1,110 @@
+package base.boudicca.api.eventcollector
+
+import base.boudicca.SemanticKeys
+import base.boudicca.api.eventcollector.collections.Collections
+import base.boudicca.api.eventcollector.util.retry
+import base.boudicca.model.Event
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.function.Consumer
+import java.util.function.Function
+
+
+class EventCollectionRunner(
+    private val eventCollectors: List<EventCollector>,
+    private val eventSink: Consumer<List<Event>>,
+    private val enricherFunction: Function<List<Event>, List<Event>>?,
+) {
+
+    private val LOG = LoggerFactory.getLogger(this::class.java)
+    private val executor = Executors.newCachedThreadPool { Thread(it).apply { isDaemon = true } } //TODO change to virtualthreads
+
+    /**
+     * executes a full collection for all configured eventcollectors
+     */
+    fun run() {
+        LOG.info("starting new full collection")
+        Collections.startFullCollection()
+        try {
+            eventCollectors
+                .map {
+                    executor.submit { collect(it) }
+                }
+                .forEach { it.get() }
+        } finally {
+            Collections.endFullCollection()
+        }
+        LOG.info("full collection done")
+    }
+
+    private fun collect(eventCollector: EventCollector) {
+        Collections.startSingleCollection(eventCollector)
+        try {
+            val events = eventCollector.collectEvents()
+            Collections.getCurrentSingleCollection()!!.totalEventsCollected = events.size
+            validateCollection(eventCollector, events)
+            try {
+                val postProcessedEvents = events.map { postProcess(it, eventCollector.getName()) }
+                val enrichedEvents = enrich(postProcessedEvents)
+                retry(LOG) {
+                    eventSink.accept(enrichedEvents)
+                }
+            } catch (e: RuntimeException) {
+                LOG.error("could not ingest events, is the core available?", e)
+            }
+        } catch (e: Exception) {
+            LOG.error("collector threw exception while collecting", e)
+        } finally {
+            Collections.endSingleCollection()
+        }
+    }
+
+    private fun validateCollection(eventCollector: EventCollector, events: List<Event>) {
+        if (events.isEmpty()) {
+            LOG.warn("collector collected 0 events!")
+        }
+        val nonBlankFields = mutableSetOf<String>()
+        val allFields = mutableSetOf<String>()
+        for (event in events) {
+            if (event.name.isBlank()) {
+                LOG.warn("event has empty name: $event")
+            }
+            if (event.data[SemanticKeys.SOURCES].isNullOrBlank()) {
+                LOG.error("event has no sources: $event")
+            }
+            for (entry in event.data.entries) {
+                allFields.add(entry.key)
+                if (entry.value.isNotBlank()) {
+                    nonBlankFields.add(entry.key)
+                }
+            }
+        }
+        for (field in allFields.minus(nonBlankFields)) {
+            LOG.warn("eventcollector ${eventCollector.getName()} has blank values for all events for field $field")
+        }
+    }
+
+    private fun enrich(events: List<Event>): List<Event> {
+        return try {
+            retry(LOG) {
+                enricherFunction?.apply(events) ?: events
+            }
+        } catch (e: Exception) {
+            LOG.error("enricher threw exception, submitting events un-enriched", e)
+            events
+        }
+    }
+
+    private fun postProcess(event: Event, collectorName: String): Event {
+        if (!event.data.containsKey(SemanticKeys.COLLECTORNAME)) {
+            return Event(
+                event.name,
+                event.startDate,
+                event.data.toMutableMap().apply { put(SemanticKeys.COLLECTORNAME, collectorName) }
+            )
+        }
+        return event
+    }
+
+}

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinator.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinator.kt
@@ -23,7 +23,7 @@ class EventCollectorCoordinator(
         }
         synchronized(this) {
             if (eventCollectorWebUi == null) {
-                eventCollectorWebUi = EventCollectorWebUi(realPort, this)
+                eventCollectorWebUi = EventCollectorWebUi(realPort, eventCollectors)
                 eventCollectorWebUi!!.start()
             }
         }

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinator.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinator.kt
@@ -1,26 +1,17 @@
 package base.boudicca.api.eventcollector
 
-import base.boudicca.SemanticKeys
-import base.boudicca.api.eventcollector.collections.Collections
-import base.boudicca.api.eventcollector.util.retry
-import base.boudicca.model.Event
 import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.util.concurrent.Executors
-import java.util.function.Consumer
-import java.util.function.Function
 
 
 class EventCollectorCoordinator(
-    private val eventCollectors: List<EventCollector>,
     private val interval: Duration,
-    private val eventSink: Consumer<List<Event>>,
-    private val enricherFunction: Function<List<Event>, List<Event>>?,
+    private val eventCollectors: List<EventCollector>,
+    private val eventCollectionRunner: EventCollectionRunner,
 ) : AutoCloseable {
 
     private val LOG = LoggerFactory.getLogger(this::class.java)
     private var eventCollectorWebUi: EventCollectorWebUi? = null
-    private val executor = Executors.newCachedThreadPool { Thread(it).apply { isDaemon = true } }
 
     fun startWebUi(port: Int = -1): EventCollectorCoordinator {
         //TODO move out of here?
@@ -42,98 +33,18 @@ class EventCollectorCoordinator(
 
     fun run(): Nothing {
         while (true) {
-            runOnce()
+            eventCollectionRunner.run()
             LOG.info("sleeping for $interval")
             Thread.sleep(interval.toMillis())
         }
     }
 
-    fun runOnce() {
-        LOG.info("starting new full collection")
-        Collections.startFullCollection()
-        try {
-            eventCollectors
-                .map {
-                    executor.submit { collect(it) }
-                }
-                .forEach { it.get() }
-        } finally {
-            Collections.endFullCollection()
-        }
-        LOG.info("full collection done")
-    }
-
-    private fun collect(eventCollector: EventCollector) {
-        Collections.startSingleCollection(eventCollector)
-        try {
-            val events = eventCollector.collectEvents()
-            Collections.getCurrentSingleCollection()!!.totalEventsCollected = events.size
-            validateCollection(eventCollector, events)
-            try {
-                val postProcessedEvents = events.map { postProcess(it, eventCollector.getName()) }
-                val enrichedEvents = enrich(postProcessedEvents)
-                retry(LOG) {
-                    eventSink.accept(enrichedEvents)
-                }
-            } catch (e: RuntimeException) {
-                LOG.error("could not ingest events, is the core available?", e)
-            }
-        } catch (e: Exception) {
-            LOG.error("collector threw exception while collecting", e)
-        } finally {
-            Collections.endSingleCollection()
-        }
-    }
-
-    private fun validateCollection(eventCollector: EventCollector, events: List<Event>) {
-        if (events.isEmpty()) {
-            LOG.warn("collector collected 0 events!")
-        }
-        val nonBlankFields = mutableSetOf<String>()
-        val allFields = mutableSetOf<String>()
-        for (event in events) {
-            if (event.name.isBlank()) {
-                LOG.warn("event has empty name: $event")
-            }
-            if (event.data[SemanticKeys.SOURCES].isNullOrBlank()) {
-                LOG.error("event has no sources: $event")
-            }
-            for (entry in event.data.entries) {
-                allFields.add(entry.key)
-                if (entry.value.isNotBlank()) {
-                    nonBlankFields.add(entry.key)
-                }
-            }
-        }
-        for (field in allFields.minus(nonBlankFields)) {
-            LOG.warn("eventcollector ${eventCollector.getName()} has blank values for all events for field $field")
-        }
-    }
-
-    private fun enrich(events: List<Event>): List<Event> {
-        return try {
-            retry(LOG) {
-                enricherFunction?.apply(events) ?: events
-            }
-        } catch (e: Exception) {
-            LOG.error("enricher threw exception, submitting events un-enriched", e)
-            events
-        }
-    }
-
-    private fun postProcess(event: Event, collectorName: String): Event {
-        if (!event.data.containsKey(SemanticKeys.COLLECTORNAME)) {
-            return Event(
-                event.name,
-                event.startDate,
-                event.data.toMutableMap().apply { put(SemanticKeys.COLLECTORNAME, collectorName) }
-            )
-        }
-        return event
-    }
-
     fun getCollectors(): List<EventCollector> {
         return eventCollectors
+    }
+
+    fun getEventCollectionRunner(): EventCollectionRunner {
+        return eventCollectionRunner
     }
 
     override fun close() {

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinator.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinator.kt
@@ -1,0 +1,147 @@
+package base.boudicca.api.eventcollector
+
+import base.boudicca.SemanticKeys
+import base.boudicca.api.eventcollector.collections.Collections
+import base.boudicca.api.eventcollector.util.retry
+import base.boudicca.model.Event
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.function.Consumer
+import java.util.function.Function
+
+
+class EventCollectorCoordinator(
+    private val eventCollectors: List<EventCollector>,
+    private val interval: Duration,
+    private val eventSink: Consumer<List<Event>>,
+    private val enricherFunction: Function<List<Event>, List<Event>>?,
+) : AutoCloseable {
+
+    private val LOG = LoggerFactory.getLogger(this::class.java)
+    private var eventCollectorWebUi: EventCollectorWebUi? = null
+    private val executor = Executors.newCachedThreadPool { Thread(it).apply { isDaemon = true } }
+
+    fun startWebUi(port: Int = -1): EventCollectorCoordinator {
+        //TODO move out of here?
+        val realPort = if (port == -1) {
+            Configuration.getProperty("server.port")?.toInt()
+                ?: throw IllegalStateException("you need to specify the server.port property!")
+        } else {
+            port
+        }
+        synchronized(this) {
+            if (eventCollectorWebUi == null) {
+                eventCollectorWebUi = EventCollectorWebUi(realPort, this)
+                eventCollectorWebUi!!.start()
+            }
+        }
+
+        return this
+    }
+
+    fun run(): Nothing {
+        while (true) {
+            runOnce()
+            LOG.info("sleeping for $interval")
+            Thread.sleep(interval.toMillis())
+        }
+    }
+
+    fun runOnce() {
+        LOG.info("starting new full collection")
+        Collections.startFullCollection()
+        try {
+            eventCollectors
+                .map {
+                    executor.submit { collect(it) }
+                }
+                .forEach { it.get() }
+        } finally {
+            Collections.endFullCollection()
+        }
+        LOG.info("full collection done")
+    }
+
+    private fun collect(eventCollector: EventCollector) {
+        Collections.startSingleCollection(eventCollector)
+        try {
+            val events = eventCollector.collectEvents()
+            Collections.getCurrentSingleCollection()!!.totalEventsCollected = events.size
+            validateCollection(eventCollector, events)
+            try {
+                val postProcessedEvents = events.map { postProcess(it, eventCollector.getName()) }
+                val enrichedEvents = enrich(postProcessedEvents)
+                retry(LOG) {
+                    eventSink.accept(enrichedEvents)
+                }
+            } catch (e: RuntimeException) {
+                LOG.error("could not ingest events, is the core available?", e)
+            }
+        } catch (e: Exception) {
+            LOG.error("collector threw exception while collecting", e)
+        } finally {
+            Collections.endSingleCollection()
+        }
+    }
+
+    private fun validateCollection(eventCollector: EventCollector, events: List<Event>) {
+        if (events.isEmpty()) {
+            LOG.warn("collector collected 0 events!")
+        }
+        val nonBlankFields = mutableSetOf<String>()
+        val allFields = mutableSetOf<String>()
+        for (event in events) {
+            if (event.name.isBlank()) {
+                LOG.warn("event has empty name: $event")
+            }
+            if (event.data[SemanticKeys.SOURCES].isNullOrBlank()) {
+                LOG.error("event has no sources: $event")
+            }
+            for (entry in event.data.entries) {
+                allFields.add(entry.key)
+                if (entry.value.isNotBlank()) {
+                    nonBlankFields.add(entry.key)
+                }
+            }
+        }
+        for (field in allFields.minus(nonBlankFields)) {
+            LOG.warn("eventcollector ${eventCollector.getName()} has blank values for all events for field $field")
+        }
+    }
+
+    private fun enrich(events: List<Event>): List<Event> {
+        return try {
+            retry(LOG) {
+                enricherFunction?.apply(events) ?: events
+            }
+        } catch (e: Exception) {
+            LOG.error("enricher threw exception, submitting events un-enriched", e)
+            events
+        }
+    }
+
+    private fun postProcess(event: Event, collectorName: String): Event {
+        if (!event.data.containsKey(SemanticKeys.COLLECTORNAME)) {
+            return Event(
+                event.name,
+                event.startDate,
+                event.data.toMutableMap().apply { put(SemanticKeys.COLLECTORNAME, collectorName) }
+            )
+        }
+        return event
+    }
+
+    fun getCollectors(): List<EventCollector> {
+        return eventCollectors
+    }
+
+    override fun close() {
+        synchronized(this) {
+            if (eventCollectorWebUi != null) {
+                eventCollectorWebUi!!.stop()
+            }
+        }
+    }
+
+}

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinator.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinator.kt
@@ -14,7 +14,6 @@ class EventCollectorCoordinator(
     private var eventCollectorWebUi: EventCollectorWebUi? = null
 
     fun startWebUi(port: Int = -1): EventCollectorCoordinator {
-        //TODO move out of here?
         val realPort = if (port == -1) {
             Configuration.getProperty("server.port")?.toInt()
                 ?: throw IllegalStateException("you need to specify the server.port property!")

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinatorBuilder.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinatorBuilder.kt
@@ -37,10 +37,10 @@ class EventCollectorCoordinatorBuilder {
     }
 
     fun build(): EventCollectorCoordinator {
-        val finalEventCollectors = eventCollectors.toList()
+        val finalEventCollectors = eventCollectors.toList() // make a copy to make it basically immutable
         return EventCollectorCoordinator(
             interval,
-            finalEventCollectors, // make a copy to make it basically immutable
+            finalEventCollectors,
             EventCollectionRunner(
                 finalEventCollectors,
                 runnerIngestionInterface ?: RunnerIngestionInterface.createFromConfiguration(),

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinatorBuilder.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinatorBuilder.kt
@@ -1,0 +1,74 @@
+package base.boudicca.api.eventcollector
+
+import base.boudicca.api.enricher.EnricherClient
+import base.boudicca.api.eventdb.ingest.EventDbIngestClient
+import base.boudicca.model.Event
+import java.time.Duration
+import java.util.function.Consumer
+import java.util.function.Function
+
+class EventCollectorCoordinatorBuilder {
+
+    private val eventCollectors: MutableList<EventCollector> = mutableListOf()
+    private var interval: Duration = Duration.ofHours(24)
+    private var eventSink = createBoudiccaEventSink(Configuration.getProperty("boudicca.eventdb.url"))
+    private var enricherFunction = createBoudiccaEnricherFunction(Configuration.getProperty("boudicca.enricher.url"))
+
+    fun addEventCollector(eventCollector: EventCollector): EventCollectorCoordinatorBuilder {
+        eventCollectors.add(eventCollector)
+        return this
+    }
+
+    fun addEventCollectors(eventCollectors: Collection<EventCollector>): EventCollectorCoordinatorBuilder {
+        this.eventCollectors.addAll(eventCollectors)
+        return this
+    }
+
+    fun setCollectionInterval(interval: Duration): EventCollectorCoordinatorBuilder {
+        this.interval = interval
+        return this
+    }
+
+    fun setEventSink(eventSink: Consumer<List<Event>>): EventCollectorCoordinatorBuilder {
+        this.eventSink = eventSink
+        return this
+    }
+
+    fun setEnricherFunction(enricherFunction: Function<List<Event>, List<Event>>): EventCollectorCoordinatorBuilder {
+        this.enricherFunction = enricherFunction
+        return this
+    }
+
+    fun build(): EventCollectorCoordinator {
+        return EventCollectorCoordinator(
+            eventCollectors.toList(), // make a copy to make it basically immutable
+            interval,
+            eventSink,
+            enricherFunction,
+        )
+    }
+
+    private fun createBoudiccaEventSink(eventDbUrl: String?): Consumer<List<Event>> {
+        if (eventDbUrl.isNullOrBlank()) {
+            throw IllegalStateException("you need to specify the boudicca.eventdb.url property!")
+        }
+        val userAndPassword = Configuration.getProperty("boudicca.ingest.auth")
+            ?: throw IllegalStateException("you need to specify the boudicca.ingest.auth property!")
+        val user = userAndPassword.split(":")[0]
+        val password = userAndPassword.split(":")[1]
+        val eventDb = EventDbIngestClient(eventDbUrl, user, password)
+        return Consumer {
+            eventDb.ingestEvents(it)
+        }
+    }
+
+    private fun createBoudiccaEnricherFunction(enricherUrl: String?): Function<List<Event>, List<Event>>? {
+        if (enricherUrl.isNullOrBlank()) {
+            return null
+        }
+        val enricher = EnricherClient(enricherUrl)
+        return Function<List<Event>, List<Event>> { events ->
+            enricher.enrichEvents(events)
+        }
+    }
+}

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinatorBuilder.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorCoordinatorBuilder.kt
@@ -40,11 +40,11 @@ class EventCollectorCoordinatorBuilder {
     }
 
     fun build(): EventCollectorCoordinator {
+        val finalEventCollectors = eventCollectors.toList()
         return EventCollectorCoordinator(
-            eventCollectors.toList(), // make a copy to make it basically immutable
             interval,
-            eventSink,
-            enricherFunction,
+            finalEventCollectors, // make a copy to make it basically immutable
+            EventCollectionRunner(finalEventCollectors, eventSink, enricherFunction)
         )
     }
 

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorDebugger.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorDebugger.kt
@@ -1,24 +1,77 @@
 package base.boudicca.api.eventcollector
 
+import base.boudicca.api.enricher.EnricherClient
 import base.boudicca.api.eventcollector.collections.Collections
 import base.boudicca.api.eventcollector.fetcher.FetcherCache
 import base.boudicca.api.eventcollector.logging.CollectionsFilter
+import base.boudicca.api.eventcollector.runner.*
+import base.boudicca.api.eventdb.ingest.EventDbIngestClient
 import base.boudicca.model.Event
 
 class EventCollectorDebugger {
+
+    private var runnerIngestionInterface: RunnerIngestionInterface? = null
+    private var runnerEnricherInterface: RunnerEnricherInterface? = null
 
     fun setFetcherCache(fetcherCache: FetcherCache): EventCollectorDebugger {
         Fetcher.fetcherCache = fetcherCache
         return this
     }
 
+    fun enableIngestion(): EventCollectorDebugger {
+        return enableIngestion(RunnerIngestionInterface.createFromConfiguration())
+    }
+
+    fun enableIngestion(eventDbUrl: String, user: String, password: String): EventCollectorDebugger {
+        return enableIngestion(EventDbIngestClient(eventDbUrl, user, password))
+    }
+
+    fun enableIngestion(ingestClient: EventDbIngestClient): EventCollectorDebugger {
+        return enableIngestion(BoudiccaRunnerIngestionInterface(ingestClient))
+    }
+
+    fun enableIngestion(runnerIngestionInterface: RunnerIngestionInterface): EventCollectorDebugger {
+        this.runnerIngestionInterface = runnerIngestionInterface
+        return this
+    }
+
+    fun enableEnricher(): EventCollectorDebugger {
+        return enableEnricher(RunnerEnricherInterface.createFromConfiguration())
+    }
+
+    fun enableEnricher(enricherUrl: String): EventCollectorDebugger {
+        return enableEnricher(EnricherClient(enricherUrl))
+    }
+
+    fun enableEnricher(enricherClient: EnricherClient): EventCollectorDebugger {
+        return enableEnricher(BoudiccaRunnerEnricherInterface(enricherClient))
+    }
+
+    fun enableEnricher(runnerEnricherInterface: RunnerEnricherInterface): EventCollectorDebugger {
+        this.runnerEnricherInterface = runnerEnricherInterface
+        return this
+    }
+
     fun debug(eventCollector: EventCollector) {
         CollectionsFilter.alsoLog = true
+        val eventCollectorAsList = listOf(eventCollector)
         val collectedEvents = mutableListOf<Event>()
-        val scheduler = EventCollectorScheduler(eventSink = { collectedEvents.addAll(it) }, enricherFunction = null)
-            .startWebUi()
-            .addEventCollector(eventCollector)
-        scheduler.runOnce()
+
+        val eventCollectorWebUi =
+            EventCollectorWebUi(Configuration.getProperty("server.port")?.toInt() ?: 8083, eventCollectorAsList)
+        eventCollectorWebUi.start()
+
+        val runner = EventCollectionRunner(
+            eventCollectorAsList,
+            {
+                collectedEvents.addAll(it)
+                if (runnerIngestionInterface != null) {
+                    runnerIngestionInterface!!.ingestEvents(it)
+                }
+            },
+            runnerEnricherInterface ?: NoopRunnerEnricherInterface
+        )
+        runner.run()
 
         collectedEvents.forEach {
             println(it)
@@ -36,7 +89,7 @@ class EventCollectorDebugger {
         }
 
         readlnOrNull()
-        scheduler.close()
+        eventCollectorWebUi.stop()
     }
 
 }

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorScheduler.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorScheduler.kt
@@ -50,7 +50,7 @@ class EventCollectorScheduler(
     }
 
     fun runOnce() {
-        getEventCollectorCoordinator().runOnce()
+        getEventCollectorCoordinator().getEventCollectionRunner().run()
     }
 
     fun getCollectors(): List<EventCollector> {

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorScheduler.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorScheduler.kt
@@ -1,178 +1,64 @@
 package base.boudicca.api.eventcollector
 
-import base.boudicca.SemanticKeys
-import base.boudicca.api.enricher.EnricherClient
-import base.boudicca.api.eventcollector.collections.Collections
-import base.boudicca.api.eventcollector.util.retry
-import base.boudicca.api.eventdb.ingest.EventDbIngestClient
 import base.boudicca.model.Event
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.util.concurrent.Executors
 import java.util.function.Consumer
 import java.util.function.Function
 
+@Deprecated("use EventCollectorCoordinator + EventCollectorCoordinatorBuilder instead")
 class EventCollectorScheduler(
     private val interval: Duration = Duration.ofHours(24),
-    private val eventSink: Consumer<List<Event>> = createBoudiccaEventSink(Configuration.getProperty("boudicca.eventdb.url")),
-    private val enricherFunction: Function<List<Event>, List<Event>>? =
-        createBoudiccaEnricherFunction(Configuration.getProperty("boudicca.enricher.url"))
+    private val eventSink: Consumer<List<Event>>? = null,
+    private val enricherFunction: Function<List<Event>, List<Event>>? = null
 ) : AutoCloseable {
 
-    private val eventCollectors: MutableList<EventCollector> = mutableListOf()
-    private val LOG = LoggerFactory.getLogger(this::class.java)
-    private var eventCollectorWebUi: EventCollectorWebUi? = null
-    private val executor = Executors.newCachedThreadPool { Thread(it).apply { isDaemon = true } }
+    private val builder = EventCollectorCoordinatorBuilder()
+    private var eventCollectorCoordinator: EventCollectorCoordinator? = null
+    private var shouldStartWebUi = false
+    private var webUiPort = -1
 
     fun addEventCollector(eventCollector: EventCollector): EventCollectorScheduler {
-        eventCollectors.add(eventCollector)
+        builder.addEventCollector(eventCollector)
         return this
     }
 
     fun startWebUi(port: Int = -1): EventCollectorScheduler {
-        val realPort = if (port == -1) {
-            Configuration.getProperty("server.port")?.toInt()
-                ?: throw IllegalStateException("you need to specify the server.port property!")
-        } else {
-            port
-        }
-        synchronized(this) {
-            if (eventCollectorWebUi == null) {
-                eventCollectorWebUi = EventCollectorWebUi(realPort, this)
-                eventCollectorWebUi!!.start()
-            }
-        }
-
+        shouldStartWebUi = true
+        webUiPort = port
         return this
     }
 
-    fun run(): Nothing {
-        while (true) {
-            runOnce()
-            LOG.info("sleeping for $interval")
-            Thread.sleep(interval.toMillis())
+    private fun getEventCollectorCoordinator(): EventCollectorCoordinator {
+        if (eventCollectorCoordinator == null) {
+            builder.setCollectionInterval(interval)
+            if (eventSink != null) {
+                builder.setEventSink(eventSink)
+            }
+            if (enricherFunction != null) {
+                builder.setEnricherFunction(enricherFunction)
+            }
+            eventCollectorCoordinator = builder.build()
+            if (shouldStartWebUi) {
+                eventCollectorCoordinator!!.startWebUi(webUiPort)
+            }
         }
+        return eventCollectorCoordinator!!
+    }
+
+    fun run(): Nothing {
+        getEventCollectorCoordinator().run()
     }
 
     fun runOnce() {
-        LOG.info("starting new full collection")
-        Collections.startFullCollection()
-        try {
-            eventCollectors
-                .map {
-                    executor.submit { collect(it) }
-                }
-                .forEach { it.get() }
-        } finally {
-            Collections.endFullCollection()
-        }
-        LOG.info("full collection done")
-    }
-
-    private fun collect(eventCollector: EventCollector) {
-        Collections.startSingleCollection(eventCollector)
-        try {
-            val events = eventCollector.collectEvents()
-            Collections.getCurrentSingleCollection()!!.totalEventsCollected = events.size
-            validateCollection(eventCollector, events)
-            try {
-                val postProcessedEvents = events.map { postProcess(it, eventCollector.getName()) }
-                val enrichedEvents = enrich(postProcessedEvents)
-                retry(LOG) {
-                    eventSink.accept(enrichedEvents)
-                }
-            } catch (e: RuntimeException) {
-                LOG.error("could not ingest events, is the core available?", e)
-            }
-        } catch (e: Exception) {
-            LOG.error("collector threw exception while collecting", e)
-        } finally {
-            Collections.endSingleCollection()
-        }
-    }
-
-    private fun validateCollection(eventCollector: EventCollector, events: List<Event>) {
-        if (events.isEmpty()) {
-            LOG.warn("collector collected 0 events!")
-        }
-        val nonBlankFields = mutableSetOf<String>()
-        val allFields = mutableSetOf<String>()
-        for (event in events) {
-            if (event.name.isBlank()) {
-                LOG.warn("event has empty name: $event")
-            }
-            if (event.data[SemanticKeys.SOURCES].isNullOrBlank()) {
-                LOG.error("event has no sources: $event")
-            }
-            for (entry in event.data.entries) {
-                allFields.add(entry.key)
-                if (entry.value.isNotBlank()) {
-                    nonBlankFields.add(entry.key)
-                }
-            }
-        }
-        for (field in allFields.minus(nonBlankFields)) {
-            LOG.warn("eventcollector ${eventCollector.getName()} has blank values for all events for field $field")
-        }
-    }
-
-    private fun enrich(events: List<Event>): List<Event> {
-        return try {
-            retry(LOG) {
-                enricherFunction?.apply(events) ?: events
-            }
-        } catch (e: Exception) {
-            LOG.error("enricher threw exception, submitting events un-enriched", e)
-            events
-        }
-    }
-
-    private fun postProcess(event: Event, collectorName: String): Event {
-        if (!event.data.containsKey(SemanticKeys.COLLECTORNAME)) {
-            return Event(
-                event.name,
-                event.startDate,
-                event.data.toMutableMap().apply { put(SemanticKeys.COLLECTORNAME, collectorName) }
-            )
-        }
-        return event
+        getEventCollectorCoordinator().runOnce()
     }
 
     fun getCollectors(): List<EventCollector> {
-        return eventCollectors
+        return getEventCollectorCoordinator().getCollectors()
     }
 
     override fun close() {
-        synchronized(this) {
-            if (eventCollectorWebUi != null) {
-                eventCollectorWebUi!!.stop()
-            }
-        }
+        getEventCollectorCoordinator().close()
     }
 
-}
-
-fun createBoudiccaEventSink(eventDbUrl: String?): Consumer<List<Event>> {
-    if (eventDbUrl.isNullOrBlank()) {
-        throw IllegalStateException("you need to specify the boudicca.eventdb.url property!")
-    }
-    val userAndPassword = Configuration.getProperty("boudicca.ingest.auth")
-        ?: throw IllegalStateException("you need to specify the boudicca.ingest.auth property!")
-    val user = userAndPassword.split(":")[0]
-    val password = userAndPassword.split(":")[1]
-    val eventDb = EventDbIngestClient(eventDbUrl, user, password)
-    return Consumer {
-        eventDb.ingestEvents(it)
-    }
-}
-
-fun createBoudiccaEnricherFunction(enricherUrl: String?): Function<List<Event>, List<Event>>? {
-    if (enricherUrl.isNullOrBlank()) {
-        return null
-    }
-    val enricher = EnricherClient(enricherUrl)
-    return Function<List<Event>, List<Event>> { events ->
-        enricher.enrichEvents(events)
-    }
 }

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorWebUi.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorWebUi.kt
@@ -20,7 +20,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
 
-class EventCollectorWebUi(port: Int, private val scheduler: EventCollectorScheduler) {
+class EventCollectorWebUi(port: Int, private val scheduler: EventCollectorCoordinator) {
 
     private val server: HttpServer
     private val ve: VelocityEngine = VelocityEngine()

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorWebUi.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/EventCollectorWebUi.kt
@@ -20,7 +20,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
 
-class EventCollectorWebUi(port: Int, private val scheduler: EventCollectorCoordinator) {
+class EventCollectorWebUi(port: Int, private val eventCollectors: List<EventCollector>) {
 
     private val server: HttpServer
     private val ve: VelocityEngine = VelocityEngine()
@@ -144,7 +144,7 @@ class EventCollectorWebUi(port: Int, private val scheduler: EventCollectorCoordi
             "warningCount" to fullCollection.getTotalWarningCount(),
             "totalEventsCollected" to fullCollection.singleCollections.sumOf { it.totalEventsCollected },
             "singleCollections" to
-                    scheduler.getCollectors()
+                    eventCollectors
                         .map { it.getName() }
                         .sorted()
                         .map {

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/BoudiccaRunnerEnricherInterface.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/BoudiccaRunnerEnricherInterface.kt
@@ -1,0 +1,10 @@
+package base.boudicca.api.eventcollector.runner
+
+import base.boudicca.api.enricher.EnricherClient
+import base.boudicca.model.Event
+
+class BoudiccaRunnerEnricherInterface(private val enricherClient: EnricherClient) : RunnerEnricherInterface {
+    override fun enrichEvents(events: List<Event>): List<Event> {
+        return enricherClient.enrichEvents(events)
+    }
+}

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/BoudiccaRunnerIngestionInterface.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/BoudiccaRunnerIngestionInterface.kt
@@ -1,0 +1,10 @@
+package base.boudicca.api.eventcollector.runner
+
+import base.boudicca.api.eventdb.ingest.EventDbIngestClient
+import base.boudicca.model.Event
+
+class BoudiccaRunnerIngestionInterface(private val ingestClient: EventDbIngestClient) : RunnerIngestionInterface {
+    override fun ingestEvents(events: List<Event>) {
+        ingestClient.ingestEvents(events)
+    }
+}

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/NoopRunnerEnricherInterface.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/NoopRunnerEnricherInterface.kt
@@ -1,0 +1,9 @@
+package base.boudicca.api.eventcollector.runner
+
+import base.boudicca.model.Event
+
+object NoopRunnerEnricherInterface : RunnerEnricherInterface {
+    override fun enrichEvents(events: List<Event>): List<Event> {
+        return events
+    }
+}

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/RunnerEnricherInterface.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/RunnerEnricherInterface.kt
@@ -1,0 +1,21 @@
+package base.boudicca.api.eventcollector.runner
+
+import base.boudicca.api.enricher.EnricherClient
+import base.boudicca.api.eventcollector.Configuration
+import base.boudicca.model.Event
+
+fun interface RunnerEnricherInterface {
+
+    companion object {
+        fun createFromConfiguration(): RunnerEnricherInterface {
+            val enricherUrl = Configuration.getProperty("boudicca.enricher.url")
+            if (enricherUrl.isNullOrBlank()) {
+                return NoopRunnerEnricherInterface
+            }
+            val enricher = EnricherClient(enricherUrl)
+            return BoudiccaRunnerEnricherInterface(enricher)
+        }
+    }
+
+    fun enrichEvents(events: List<Event>): List<Event>
+}

--- a/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/RunnerIngestionInterface.kt
+++ b/boudicca.base/eventcollector-client/src/main/kotlin/base/boudicca/api/eventcollector/runner/RunnerIngestionInterface.kt
@@ -1,0 +1,25 @@
+package base.boudicca.api.eventcollector.runner
+
+import base.boudicca.api.eventcollector.Configuration
+import base.boudicca.api.eventdb.ingest.EventDbIngestClient
+import base.boudicca.model.Event
+
+fun interface RunnerIngestionInterface {
+
+    companion object {
+        fun createFromConfiguration(): RunnerIngestionInterface {
+            val eventDbUrl = Configuration.getProperty("boudicca.eventdb.url")
+            if (eventDbUrl.isNullOrBlank()) {
+                throw IllegalStateException("you need to specify the boudicca.eventdb.url property!")
+            }
+            val userAndPassword = Configuration.getProperty("boudicca.ingest.auth")
+                ?: throw IllegalStateException("you need to specify the boudicca.ingest.auth property!")
+            val user = userAndPassword.split(":")[0]
+            val password = userAndPassword.split(":")[1]
+            val eventDb = EventDbIngestClient(eventDbUrl, user, password)
+            return BoudiccaRunnerIngestionInterface(eventDb)
+        }
+    }
+
+    fun ingestEvents(events: List<Event>)
+}

--- a/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/BoudiccaEventCollectors.kt
+++ b/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/BoudiccaEventCollectors.kt
@@ -1,11 +1,10 @@
 package events.boudicca.eventcollector
 
-import base.boudicca.api.eventcollector.EventCollectorScheduler
+import base.boudicca.api.eventcollector.EventCollectorCoordinatorBuilder
 import events.boudicca.eventcollector.collectors.*
 
 fun main() {
-    EventCollectorScheduler()
-        .startWebUi()
+    val eventCollectorCoordinator = EventCollectorCoordinatorBuilder()
         .addEventCollector(LinzTermineCollector())
         .addEventCollector(PosthofCollector())
         .addEventCollector(JkuEventCollector())
@@ -35,5 +34,8 @@ fun main() {
         .addEventCollector(OKHVoecklabruckCollector())
         .addEventCollector(ValugCollector())
         .addEventCollector(AlpenverreinCollector())
-        .run()
+        .build()
+
+    eventCollectorCoordinator.startWebUi()
+    eventCollectorCoordinator.run()
 }

--- a/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/LocalCollectorDebug.kt
+++ b/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/LocalCollectorDebug.kt
@@ -10,6 +10,12 @@ fun main() {
         // this debugger caches all fetcher calls locally to avoid spamming the server when developing.
         // if there are problems with old data or something like that just delete the file and restart the debugger
         .setFetcherCache(FileBackedFetcherCache(File("./fetcher.cache")))
+        //enable one of the two lines to also use the online or local enricher
+//        .enableEnricher("https://enricher.boudicca.events")
+//        .enableEnricher("http://localhost:8085")
+        //enable this line to ingest the collected events into the local eventdb (this uses the configuration from the application.properties)
+//        .enableIngestion()
+
 //        .debug(TechnologiePlauscherlCollector())
 //        .debug(JkuEventCollector())
 //        .debug(PosthofCollector())

--- a/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/LocalFetchFromOnlineBoudicca.kt
+++ b/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/LocalFetchFromOnlineBoudicca.kt
@@ -1,12 +1,16 @@
 package events.boudicca.eventcollector
 
-import base.boudicca.api.eventcollector.EventCollectorScheduler
-import base.boudicca.api.eventcollector.collections.Collections
+import base.boudicca.api.eventcollector.EventCollectionRunner
 import base.boudicca.api.eventcollector.collectors.BoudiccaCollector
+import base.boudicca.api.eventcollector.logging.CollectionsFilter
+import base.boudicca.api.eventcollector.runner.RunnerEnricherInterface
+import base.boudicca.api.eventcollector.runner.RunnerIngestionInterface
 
 fun main() {
-    EventCollectorScheduler()
-        .addEventCollector(BoudiccaCollector("https://eventdb.boudicca.events"))
-        .runOnce()
-    Collections.getAllPastCollections()[0].getAllLogLines().forEach { println(it) }
+    CollectionsFilter.alsoLog = true
+    EventCollectionRunner(
+        listOf(BoudiccaCollector("https://eventdb.boudicca.events")),
+        RunnerIngestionInterface.createFromConfiguration(),
+        RunnerEnricherInterface.createFromConfiguration()
+    ).run()
 }


### PR DESCRIPTION
okee, bigger refactoring of the EventCollectorScheduler class
mainly i broke it up into 2 pieces:

- EventCollectorCoordinator: responsible for scheduling event collections via the new EventCollectionRunner and starting/stopping of the webui. should be build via the EventCollectorCoordinatorBuilder
- EventCollectionRunnger: responsible for actually calling all the EventCollectors and then doing all the validation, postprocessing, enrichment and ingestion

this change also introduces new functionality in the EventCollectorDebugger, mainly allowing easy enablement of enriching and ingesting. so no need to run the actual collection to test your new EventCollector locally

i will update a lot of documentation hopefully tomorrow...