### PR TITLE
Fix time zone of fhLUG events

### DIFF
--- a/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/collectors/FhLugCollector.kt
+++ b/boudicca.events/eventcollectors/src/main/kotlin/events/boudicca/eventcollector/collectors/FhLugCollector.kt
@@ -12,7 +12,6 @@ import org.jsoup.Jsoup
 import org.slf4j.LoggerFactory
 import java.io.StringReader
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
@@ -92,11 +91,10 @@ class FhLugCollector : TwoStepEventCollector<VEvent>("fhLUG") {
     }
 
     private fun parseStartDate(event: VEvent): OffsetDateTime {
-        val startTime = when (val startDate = dateTimeFormatter.parseBest(event.startDate.value, LocalDateTime::from, LocalDate::from)) {
-            is LocalDateTime -> startDate
-            is LocalDate -> startDate.atStartOfDay()
+        return when (val startDate = dateTimeFormatter.parseBest(event.startDate.value, OffsetDateTime::from, LocalDate::from)) {
+            is OffsetDateTime -> startDate
+            is LocalDate -> startDate.atStartOfDay().atZone(viennaZoneId).toOffsetDateTime()
             else -> throw IllegalArgumentException("Unsupported temporal accessor")
         }
-        return startTime.atZone(viennaZoneId).toOffsetDateTime()
     }
 }


### PR DESCRIPTION
Time zones are one huge PITA. The start time of events was erroneously shifted twice, ending up with start times 2 hours too early. ics evnets already have the timezone specified, so we can parse directly to an OffsetTimeZone. For date-only events ("full day"), use the old logic so that they start at midnight, local time.

Thanks!