### PR TITLE
add update-gradle-wrapper-action because dependabot can not update the gradle wrapper

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,15 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
See also: https://github.com/gradle-update/update-gradle-wrapper-action
And feel free to upvote the feature request/discussion here: https://github.com/dependabot/dependabot-core/issues/2223