### PR TITLE
Add PAT to update-gradle-wrapper action

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest
-    environment: ci
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -4,18 +4,16 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest
+    environment: ci
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: true
-
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v2
+        with:
+          repo-token: ${{ secrets.YOLGIE_PAT_UPGRADE_GRADLEW_ACTION }}
+          pr-title-template: 'build(deps): Bump Gradle Wrapper from %sourceVersion% to %targetVersion%'
+          labels: dependencies


### PR DESCRIPTION
the GITHUB token can apparently not create PRs which will trigger our CI so we need the PAT...

See: https://github.com/gradle-update/update-gradle-wrapper-action?tab=readme-ov-file#running-ci-workflows-in-pull-requests-created-by-the-action