### PR TITLE
Potential fix for code scanning alert no. 10: Disabled Spring CSRF protection

### DIFF
--- a/boudicca.base/eventdb/src/main/kotlin/base/boudicca/eventdb/EventDBApplication.kt
+++ b/boudicca.base/eventdb/src/main/kotlin/base/boudicca/eventdb/EventDBApplication.kt
@@ -42,9 +42,7 @@ class EventDBApplication : WebMvcConfigurer {
             it.requestMatchers("/**").permitAll()
         }
         http.httpBasic(withDefaults())
-        http.csrf {
-            it.disable()
-        }
+        http.csrf(withDefaults())
         return http.build()
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/boudicca-events/boudicca.events/security/code-scanning/10](https://github.com/boudicca-events/boudicca.events/security/code-scanning/10)

To fix the problem, we need to enable CSRF protection in the `filterChain` method. This can be done by removing the line that disables CSRF protection (`it.disable()`). By default, Spring Security enables CSRF protection, so no additional configuration is needed to enable it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
