### PR TITLE
fix: add explcit security permissions to update gradle wrapper action

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: # this can be restrictive since there as a granular personal access token that is used to open the MergeRequest
+  contents: read
+  pull-requests: read
+
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See: https://github.com/boudicca-events/boudicca.events/security/code-scanning/16