### PR TITLE
build: fix JVM toolchain configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,2 +1,2 @@
 version = file("version.txt").readText()
-ext["jvmVersion"] = 21
+ext["jvmVersion"] = 21 // be careful to keep this in sync with the buildSrc/build.gradle.kts

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,3 +10,7 @@ repositories {
 dependencies {
     implementation(libs.bundles.boudicca.plugins)
 }
+
+kotlin {
+    jvmToolchain(21) // be careful to keep this in sync with the global build.gradle.kts
+}


### PR DESCRIPTION
needed to be added to the buildSrc/build.gradle.kts as well, i found no sensible way to have this done as a single source of truth somewhere, this resolves all these errors/warnings:
* Kotlin does not yet support 25 JDK target, falling back to Kotlin JVM_24 JVM target
* Inconsistent JVM Target Compatibility Between Java and Kotlin Tasks
* Inconsistent JVM-target compatibility detected for tasks 'compileJava' (25) and 'compileKotlin' (24)