### PR TITLE
Remove unused findbugs dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ jackson = "2.19.2"
 jackson-databind-nullable = "0.2.8"
 jakarta-annotation = "3.0.0"
 javax-jaxrs = "2.1.1"
-findbugs = "3.0.2"
 spring-openapi-starter = "2.8.9"
 spring = "6.5.6"
 spring-boot = "3.5.6"
@@ -42,7 +41,6 @@ spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-star
 spring-boot-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "spring-boot" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "spring-boot" }
 
-findbugs = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs" }
 
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
@@ -128,7 +126,7 @@ jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 #following bundles are applied by the plugins with the same name
 openapi-generate-spec = ["swagger-annotations", "javax-jaxrs"]
 #TODO test if those dependencies are really necessary
-openapi-generate-client = ["findbugs", "jackson-core", "jackson-annotations", "jackson-databind", "jackson-databind-jsr310", "jackson-databind-nullable", "jakarta-annotation"]
+openapi-generate-client = ["jackson-core", "jackson-annotations", "jackson-databind", "jackson-databind-jsr310", "jackson-databind-nullable", "jakarta-annotation"]
 
 #all third-party plugins applied by our boudicca-* plugins
 boudicca-plugins = ["org-jetbrains-kotlin-jvm-gradle-plugin", "org-jetbrains-kotlin-plugin-spring-gradle-plugin", "io-gitlab-arturbosch-detekt-gradle-plugin", "org-springframework-boot-gradle-plugin", "org-openapi-generator-gradle-plugin", "io-swagger-core-v3-swagger-gradle-plugin"]


### PR DESCRIPTION
## Summary
- remove the unused findbugs/jsr305 entry from the version catalog
- update the OpenAPI client generation bundle to omit the unneeded dependency

## Testing
- ./gradlew :buildSrc:assemble --console=plain --no-daemon


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69378fcd0f7c8329838766e4bc86af44)