### PR TITLE
fix(ci): removed debug output from DateParserTest.kt

### DIFF
--- a/boudicca.base/dateparser-lib/src/test/kotlin/base/boudicca/api/eventcollector/dateparser/DateParserTest.kt
+++ b/boudicca.base/dateparser-lib/src/test/kotlin/base/boudicca/api/eventcollector/dateparser/DateParserTest.kt
@@ -308,7 +308,7 @@ class DateParserTest {
         ): Triple<List<String>, List<DatePair>, DateParserConfig> {
             return Triple(
                 dateText, expected, config ?: DateParserConfig(
-                    alwaysPrintDebugTracing = true
+                    alwaysPrintDebugTracing = false // set true to get more debug info
                 )
             )
         }
@@ -325,8 +325,8 @@ class DateParserTest {
             val clock = Clock.fixed(OffsetDateTime.parse(fixedClockDate).toInstant(), ZoneId.of("Europe/Vienna"))
             return testDate(
                 listOf(dateText), listOf(expected), DateParserConfig(
-                    alwaysPrintDebugTracing = true,
-                    clock = clock
+                    clock = clock,
+                    alwaysPrintDebugTracing = false // set true to get more debug info
                 )
             )
         }
@@ -339,7 +339,7 @@ class DateParserTest {
             return testDate(
                 listOf(dateText), listOf(expected), DateParserConfig(
                     dayMonthOrder = dayMonthOrder,
-                    alwaysPrintDebugTracing = true,
+                    alwaysPrintDebugTracing = false // set true to get more debug info
                 )
             )
         }


### PR DESCRIPTION
@kadhonn should we disable this for the checked in version? it creates ~3k lines of output in the logs 😅