### PR TITLE
Migrate OpenAPI spec generation to Jakarta JAX-RS

### DIFF
--- a/boudicca.base/enricher-api/src/main/kotlin/base/boudicca/api/enricher/EnricherApi.kt
+++ b/boudicca.base/enricher-api/src/main/kotlin/base/boudicca/api/enricher/EnricherApi.kt
@@ -5,10 +5,10 @@ import base.boudicca.model.Event
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import javax.ws.rs.Consumes
-import javax.ws.rs.POST
-import javax.ws.rs.Path
-import javax.ws.rs.Produces
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
 
 @OpenAPIDefinition
 interface EnricherApi {

--- a/boudicca.base/eventdb-api/src/main/kotlin/base/boudicca/api/eventdb/IngestionApi.kt
+++ b/boudicca.base/eventdb-api/src/main/kotlin/base/boudicca/api/eventdb/IngestionApi.kt
@@ -4,9 +4,9 @@ import base.boudicca.model.Entry
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import javax.ws.rs.Consumes
-import javax.ws.rs.POST
-import javax.ws.rs.Path
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
 
 @OpenAPIDefinition
 @Path("/ingest")

--- a/boudicca.base/eventdb-api/src/main/kotlin/base/boudicca/api/eventdb/PublisherApi.kt
+++ b/boudicca.base/eventdb-api/src/main/kotlin/base/boudicca/api/eventdb/PublisherApi.kt
@@ -5,10 +5,10 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.util.UUID
-import javax.ws.rs.GET
-import javax.ws.rs.Path
-import javax.ws.rs.PathParam
-import javax.ws.rs.Produces
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
 
 @OpenAPIDefinition
 interface PublisherApi {

--- a/boudicca.base/remote-collector/remote-collector-api/src/main/kotlin/base/boudicca/api/remotecollector/RemoteCollectorApi.kt
+++ b/boudicca.base/remote-collector/remote-collector-api/src/main/kotlin/base/boudicca/api/remotecollector/RemoteCollectorApi.kt
@@ -4,9 +4,9 @@ import base.boudicca.api.remotecollector.model.EventCollection
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import javax.ws.rs.GET
-import javax.ws.rs.Path
-import javax.ws.rs.Produces
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
 
 @OpenAPIDefinition
 fun interface RemoteCollectorApi {

--- a/boudicca.base/search-api/src/main/kotlin/base/boudicca/api/search/SearchApi.kt
+++ b/boudicca.base/search-api/src/main/kotlin/base/boudicca/api/search/SearchApi.kt
@@ -7,10 +7,10 @@ import base.boudicca.api.search.model.ResultDTO
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import javax.ws.rs.Consumes
-import javax.ws.rs.POST
-import javax.ws.rs.Path
-import javax.ws.rs.Produces
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
 
 @OpenAPIDefinition
 interface SearchApi {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ detekt = "2.0.0-alpha.1"
 jackson = "2.19.2"
 jackson-databind-nullable = "0.2.8"
 jakarta-annotation = "3.0.0"
-javax-jaxrs = "2.1.1"
+jakarta-jaxrs = "3.1.0"
 spring-openapi-starter = "2.8.9"
 spring = "6.5.6"
 spring-boot = "3.5.6"
@@ -51,7 +51,7 @@ jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-
 jackson-databind-nullable = { module = "org.openapitools:jackson-databind-nullable", version.ref = "jackson-databind-nullable" }
 
 jakarta-annotation = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation" }
-javax-jaxrs = { module = "javax.ws.rs:javax.ws.rs-api", version.ref = "javax-jaxrs" }
+jakarta-jaxrs = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "jakarta-jaxrs" }
 
 swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swagger-core-version" }
 
@@ -124,7 +124,7 @@ jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 [bundles]
 
 #following bundles are applied by the plugins with the same name
-openapi-generate-spec = ["swagger-annotations", "javax-jaxrs"]
+openapi-generate-spec = ["swagger-annotations", "jakarta-jaxrs"]
 #TODO test if those dependencies are really necessary
 openapi-generate-client = ["jackson-core", "jackson-annotations", "jackson-databind", "jackson-databind-jsr310", "jackson-databind-nullable", "jakarta-annotation"]
 


### PR DESCRIPTION
## Summary
- replace the legacy javax JAX-RS dependency with the Jakarta ws.rs API in the version catalog and OpenAPI spec generation bundle
- update OpenAPI-exposed API interfaces to import jakarta.ws.rs annotations

## Testing
- `./gradlew clean build --console=plain` *(fails: unresolved references to dateparser classes in boudicca.base:dateparser-lib tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d21e1db08329b20bec75a6b2bdad)