### PR TITLE
Add commons-lang3 constraint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,3 +34,9 @@ sonar {
         )
     }
 }
+
+subprojects {
+    configurations.matching { it.name == "implementation" }.all {
+        project.dependencies.constraints.add(name, "org.apache.commons:commons-lang3:3.18.0")
+    }
+}


### PR DESCRIPTION
## Summary
- enforce org.apache.commons:commons-lang3 version 3.18.0 via subproject constraints

## Testing
- ./gradlew --no-daemon :boudicca.events:eventcollectors:dependencyInsight --configuration runtimeClasspath --dependency commons-lang3 --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b68689010832989a4ab2eca3f3c0a)